### PR TITLE
add support for `aws-lc-rs` and make `ring` optional

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@cargo-nextest
       - uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Run tests
+      - name: Run tests w/ aws-lc-rs (default)
         run: cargo llvm-cov nextest --profile ci
+      - name: Run tests w/ ring (optional)
+        run: >
+          cargo llvm-cov nextest
+          --no-default-features
+          --features ring
       - name: Generate coverage report
         run: cargo llvm-cov report --codecov --output-path coverage.json
       - name: Upload test results to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Tests
 on:
   push:
     branches: [ "main" ]
@@ -7,7 +7,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Postgres Image

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,14 @@ edition = "2018"
 license = "MIT"
 readme = "README.md"
 
+[features]
+default = ["aws-lc-rs"]
+aws-lc-rs = ["rustls/aws-lc-rs"]
+ring = ["rustls/ring"]
+
 [dependencies]
-const-oid = { version = "0.9.6", default-features = false, features = ["db"] }
-ring = { version = "0.17", default-features = false }
 rustls = { version = "0.23", default-features = false }
+sha2 = { version = "0.10", default-features = false, features = ["oid"] }
 tokio = { version = "1", default-features = false }
 tokio-postgres = { version = "0.7", default-features = false, features = [
   "runtime",
@@ -29,11 +33,11 @@ tokio-rustls = { version = "0.26", default-features = false }
 x509-cert = { version = "0.2.5", default-features = false, features = ["std"] }
 
 [dev-dependencies]
-tokio = { version = "1", default-features = false, features = ["macros", "rt"] }
+bollard = { version = "0.19.2" }
 rustls = { version = "0.23", default-features = false, features = [
   "std",
   "logging",
   "tls12",
-  "ring",
 ] }
-bollard = { version = "0.19.2" }
+sha2 = { version = "0.10", default-features = false, features = ["std", "oid"] }
+tokio = { version = "1", default-features = false, features = ["macros", "rt"] }

--- a/README.md
+++ b/README.md
@@ -3,9 +3,14 @@
 [![codecov](https://codecov.io/github/dsykes16/tokio-postgres-rustls/graph/badge.svg?token=PKUZQ62OP8)](https://codecov.io/github/dsykes16/tokio-postgres-rustls)
 [![tests](https://github.com/dsykes16/tokio-postgres-rustls/actions/workflows/rust.yml/badge.svg)](https://github.com/dsykes16/tokio-postgres-rustls/actions/workflows/rust.yml)
 
-NOTE: This is a fork; the original [tokio-postgres-rustls](https://github.com/jbg/tokio-postgres-rustls) repo appears to be unmaintained and has known bugs.
+NOTE: This is a fork; the original [tokio-postgres-rustls](https://github.com/jbg/tokio-postgres-rustls) repo appears to be unmaintained and has known bugs with virtually no test coverage or CI pipeline.
 
-This fork strives to be actively maintained, and incorporates [Conrad Ludgate](https://github.com/conradludgate)'s fixes for [SCRAM channel binding](https://github.com/jbg/tokio-postgres-rustls/pull/32) and [removal of unsafe code](https://github.com/jbg/tokio-postgres-rustls/pull/33), this fork also adds comprehensive integration tests and a CI pipeline.
+## Improvements over original [`tokio-postgres-rustls`](https://github.com/jbg/tokio-postgres-rustls):
+
+- Removed unsafe code (thanks @conradludgate)
+- Fixes SCRAM/SASL channel binding
+- Add support for `aws-lc-rs` instead of `ring` (defaults to `aws-lc-rs`; consistent with `rustls` defaults)
+- Added comprehensive integration test suite that runs with both `ring` and `aws-lc-rs`
 
 This is an integration between the [rustls TLS stack](https://github.com/ctz/rustls)
 and the [tokio-postgres asynchronous PostgreSQL client library](https://github.com/sfackler/rust-postgres).
@@ -24,7 +29,7 @@ Patch in our fork that maintains the original crate name like this:
 
 ```toml
 [patch.crates-io]
-tokio-postgres-rustls = { git = "https://github.com/khorsolutions/tokio-postgres-rustls.git", tag = "0.14.0" }
+tokio-postgres-rustls = { git = "https://github.com/khorsolutions/tokio-postgres-rustls.git", tag = "0.15.0" }
 ```
 
 ## Example

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  range: "80..100"
+  status:
+    project:
+      default:
+        target: 80%
+    patch:
+      default:
+        target: 80%


### PR DESCRIPTION
- Refactor channel binding code
- Remove hard dependency on `ring`
- Default to `aws-lc-rs` feature
- Add optional `ring` feature
- Add separate CI pipeline to test `ring`